### PR TITLE
🔧 Remove unused fields and simplify card components

### DIFF
--- a/app/(with-layout)/(almacen-cafeteria)/ventas-cafeteria/types.ts
+++ b/app/(with-layout)/(almacen-cafeteria)/ventas-cafeteria/types.ts
@@ -27,7 +27,6 @@ export interface TarjetasVentas {
   id: number;
   nombre: string;
   banco: Banco;
-  isAvailable: boolean;
 }
 
 export interface ResponseVentasCafeteria {

--- a/app/(with-layout)/tarjetas/page.tsx
+++ b/app/(with-layout)/tarjetas/page.tsx
@@ -1,11 +1,4 @@
-import {
-  Card,
-  CardContent,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/card';
-import { Progress } from '@/components/ui/progress';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { GetTarjetas } from './services';
 import { CloudOff, EllipsisVertical } from 'lucide-react';
 import SheetTarjetas from '@/components/functionals/sheets/SheetTarjetas';
@@ -23,8 +16,6 @@ import {
 } from '@/components/ui/dropdown-menu';
 import SheetTransferenciasTarjetas from '@/components/functionals/sheets/SheetTransferenciasTarjetas';
 import Delete from './client';
-
-const MAX_TRANF_MES = 120000;
 
 export default async function Tarjetas() {
   const { data, error } = await GetTarjetas();
@@ -69,29 +60,6 @@ export default async function Tarjetas() {
                 }).format(tarjeta.balance.valor)}
               </p>
             </CardContent>
-            <CardFooter>
-              <div className="w-full">
-                <p className="text-xs text-right">
-                  {Intl.NumberFormat('es-ES', {
-                    style: 'decimal',
-                    maximumFractionDigits: 2,
-                  }).format(tarjeta.total_transferencias_mes)}
-                  /{MAX_TRANF_MES}
-                </p>
-                <Progress
-                  className={cn(
-                    '[&>div]:bg-white mt-2',
-                    (tarjeta.total_transferencias_mes * 100) / MAX_TRANF_MES >=
-                      80 && '[&>div]:bg-red-600',
-                    (tarjeta.total_transferencias_mes * 100) / MAX_TRANF_MES >=
-                      60 && '[&>div]:bg-yellow-400'
-                  )}
-                  value={
-                    (tarjeta.total_transferencias_mes * 100) / MAX_TRANF_MES
-                  }
-                />
-              </div>
-            </CardFooter>
           </Card>
         ))}
         <SheetTarjetas isError={!!error} />

--- a/app/(with-layout)/tarjetas/types.ts
+++ b/app/(with-layout)/tarjetas/types.ts
@@ -20,8 +20,6 @@ export interface Tarjetas {
   nombre: string;
   banco: Banco;
   balance: BalanceTarjetas;
-  total_transferencias_mes: number;
-  total_transferencias_dia: number;
 }
 
 export interface Transferenciastarjetas {

--- a/components/functionals/ModalVentas.jsx
+++ b/components/functionals/ModalVentas.jsx
@@ -23,13 +23,12 @@ import {
   FormControl,
   FormField,
   FormItem,
-  FormLabel,
   FormMessage,
 } from '@/components/ui/form';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { CheckIcon, X, PlusCircle, ChevronDown } from 'lucide-react';
 
-import { cn, MAX_TRANF_DIA, MAX_TRANF_MES } from '@/lib/utils';
+import { cn } from '@/lib/utils';
 import {
   Command,
   CommandEmpty,
@@ -254,11 +253,6 @@ export default function ModalVentas({
                           <SelectItem
                             key={tarjeta.id}
                             value={tarjeta.id.toString()}
-                            disabled={
-                              tarjeta.total_transferencias_mes >=
-                                MAX_TRANF_MES ||
-                              tarjetas.total_transferencias_dia >= MAX_TRANF_DIA
-                            }
                           >
                             <div className="flex gap-2 items-center ">
                               <div

--- a/components/functionals/sheets/SheetTarjetas.tsx
+++ b/components/functionals/sheets/SheetTarjetas.tsx
@@ -72,7 +72,7 @@ export default function SheetTarjetas({ isError }: { isError: boolean }) {
       <SheetTrigger disabled={isError}>
         <Card
           style={{ flex: '0 0 auto', scrollSnapAlign: 'start' }}
-          className="aspect-video h-full cursor-pointer min-h-40"
+          className="aspect-video h-full cursor-pointer"
         >
           <CardContent className="text-black/40 h-full p-8 flex flex-col gap-2 justify-center items-center">
             <PlusSquare size={24} />

--- a/components/functionals/sheets/SheetTransferenciasTarjetas.tsx
+++ b/components/functionals/sheets/SheetTransferenciasTarjetas.tsx
@@ -18,7 +18,7 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import { Label } from '@/components/ui/label';
-import { useForm, useWatch } from 'react-hook-form';
+import { useForm } from 'react-hook-form';
 import { valibotResolver } from '@hookform/resolvers/valibot';
 import { TransferenciasTarjetas } from '@/lib/schemas';
 
@@ -63,11 +63,6 @@ export default function SheetTransferenciasTarjetas({
     },
   });
 
-  const tipo = useWatch({
-    control: form.control,
-    name: 'tipo',
-  });
-
   const onSubmit = async (
     dataForm: InferInput<typeof TransferenciasTarjetas>
   ): Promise<void> => {
@@ -82,9 +77,6 @@ export default function SheetTransferenciasTarjetas({
       setOpen(false);
     }
   };
-
-  const MAX_TRANF_MES = 120000;
-  const MAX_TRANF_DIA = 80000;
 
   return (
     <Sheet open={open} onOpenChange={setOpen} modal={true}>
@@ -170,13 +162,6 @@ export default function SheetTransferenciasTarjetas({
                           <SelectItem
                             key={tarjeta.id}
                             value={tarjeta.id.toString()}
-                            disabled={
-                              tipo === TipoTransferencia.EGRESO &&
-                              (tarjeta.total_transferencias_mes >=
-                                MAX_TRANF_MES ||
-                                tarjeta.total_transferencias_dia >=
-                                  MAX_TRANF_DIA)
-                            }
                           >
                             <div className="flex gap-2 items-center ">
                               <div

--- a/components/functionals/sheets/SheetVentasCafeteria.tsx
+++ b/components/functionals/sheets/SheetVentasCafeteria.tsx
@@ -9,13 +9,7 @@ import {
   SheetTrigger,
 } from '@/components/ui/sheet';
 import { Button } from '@/components/ui/button';
-import {
-  CirclePlus,
-  CircleX,
-  MinusCircle,
-  Pen,
-  PlusCircle,
-} from 'lucide-react';
+import { CirclePlus, CircleX, MinusCircle, PlusCircle } from 'lucide-react';
 import {
   Form,
   FormControl,
@@ -259,7 +253,6 @@ export default function SheetVentasCafeteria({
                             <SelectItem
                               key={tarjeta.id}
                               value={tarjeta.id.toString()}
-                              disabled={!tarjeta.isAvailable}
                             >
                               <div className="flex gap-2 items-center ">
                                 <div


### PR DESCRIPTION
- Removed `isAvailable` from TarjetasVentas type in ventas-cafeteria
- Deleted transfer-related fields from Tarjetas type
- Removed progress bar and transfer limit logic from Tarjetas page
- Simplified SheetTarjetas card styling
- Cleaned up unused imports and constants in various components