### PR TITLE
🔧 Add new authorized area for sales tab access

### DIFF
--- a/app/(with-layout)/areas-de-venta/[id]/page.tsx
+++ b/app/(with-layout)/areas-de-venta/[id]/page.tsx
@@ -23,8 +23,6 @@ export default async function AreaVenta({ params }: { params: Params }) {
 
   let is_authorized = false;
 
-  console.log(area_venta);
-
   if (isStaff) {
     is_authorized = true;
   } else if (area_venta) {
@@ -32,6 +30,7 @@ export default async function AreaVenta({ params }: { params: Params }) {
       if (
         area_venta === '4' ||
         area_venta === '6' ||
+        area_venta === '25' ||
         area_venta === params.id
       ) {
         is_authorized = true;


### PR DESCRIPTION
- Included '25' as an additional authorized area in the sales tab authorization logic
- Removed debug console.log statement
- Simplified area authorization condition