### PR TITLE
🎨 Adjust transfer progress bar color thresholds in Tarjetas page

### DIFF
--- a/app/(with-layout)/tarjetas/page.tsx
+++ b/app/(with-layout)/tarjetas/page.tsx
@@ -93,9 +93,9 @@ export default async function Tarjetas() {
                   className={cn(
                     '[&>div]:bg-white mt-2',
                     (tarjeta.total_transferencias_mes * 100) / MAX_TRANF_MES >=
-                      80 && '[&>div]:bg-red-600',
+                      60 && '[&>div]:bg-yellow-400',
                     (tarjeta.total_transferencias_mes * 100) / MAX_TRANF_MES >=
-                      60 && '[&>div]:bg-yellow-400'
+                      80 && '[&>div]:bg-red-600'
                   )}
                   value={
                     (tarjeta.total_transferencias_mes * 100) / MAX_TRANF_MES


### PR DESCRIPTION
- Swapped color thresholds for transfer progress bar
- Updated background color conditions to trigger at 60% and 80% of max transfers
- Improved visual feedback for transfer limit tracking