### PR TITLE
🔄 Agregando lógica para mostrar un badge en la columna de proveedores…

### DIFF
--- a/app/(with-layout)/entradas/columns.tsx
+++ b/app/(with-layout)/entradas/columns.tsx
@@ -35,6 +35,10 @@ export const columns: ColumnDef<Entrada>[] = [
   {
     accessorKey: 'nombre_proveedor',
     header: 'Proveedor',
+    cell: ({ row }) => {
+      const proveedor = row.getValue('nombre_proveedor');
+      return proveedor ? proveedor : <Badge variant="outline">Vacío</Badge>;
+    },
   },
   {
     accessorKey: 'metodo_pago',


### PR DESCRIPTION
… cuando el nombre del proveedor está vacío, mejorando la visualización de datos en la tabla de entradas.