### PR TITLE
Enhance EntradaSchema validation for payment method selection

### DIFF
--- a/app/(with-layout)/create-entrada/schema.ts
+++ b/app/(with-layout)/create-entrada/schema.ts
@@ -131,6 +131,7 @@ export const EntradaSchema = pipe(
     partialCheck(
       ["metodoPago", "cuentas"] as any[],
       (input) => {
+        if (input.metodoPago !== METODOS_PAGO.MIXTO) return true;
         if (input.metodoPago === METODOS_PAGO.MIXTO && input.cuentas.length < 2)
           return false;
 


### PR DESCRIPTION
- Added a condition to bypass validation for payment methods other than MIXTO in the EntradaSchema.
- Ensured that the validation for the cuentas field only applies when the MIXTO payment method is selected.